### PR TITLE
Add unixodbc

### DIFF
--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -293,6 +293,21 @@ modules:
       - /lib32/samba
     sources: *samba-sources
 
+  - name: unixodbc
+    sources: &unixodbc-sources
+      - type: archive
+        url: http://www.unixodbc.org/unixODBC-2.3.9.tar.gz
+        sha256: 52833eac3d681c8b0c9a5a65f2ebd745b3a964f208fc748f977e44015a31b207
+    cleanup: &unixodbc-cleanup
+      - /bin
+
+  - name: unixodbc-32bit
+    build-options:
+      arch:
+        x86_64: *compat_i386_opts
+    sources: *unixodbc-sources
+    cleanup: *unixodbc-cleanup
+
   # Native arch build
 
   - name: wine

--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -255,8 +255,8 @@ modules:
       - /sbin
     sources: &samba-sources
       - type: archive
-        url: https://download.samba.org/pub/samba/samba-4.15.5.tar.gz
-        sha256: 69115e33831937ba5151be0247943147765aece658ba743f44741672ad68d17f
+        url: https://download.samba.org/pub/samba/samba-4.15.6.tar.gz
+        sha256: 0575b999a9048445820428dc540ba8a9527ce596fa66af02ea2ba1ea9578bcb4
     modules:
       - name: parse-yapp
         buildsystem: simple


### PR DESCRIPTION
Some applications depend on [ODBC](https://wiki.winehq.org/Wine_User%27s_Guide#ODBC_Databases), but this flatpak app is currently lacking the unix-side library, unixodbc (libodbc.so).

In the meanwhile, upgrade samba, as 4.15.5 is not available anymore on [download.samba.org](https://download.samba.org/pub/samba/).