### PR TITLE
Update vkd3d to 1.9 + chores

### DIFF
--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -183,8 +183,8 @@ modules:
   - name: vkd3d
     sources: &vkd3d-sources
       - type: archive
-        url: https://dl.winehq.org/vkd3d/source/vkd3d-1.5.tar.xz
-        sha256: e3b3c355f46f7cbfc19e710a478bcb2bee267a5f360e7e6406238cea52ce2cfc
+        url: https://dl.winehq.org/vkd3d/source/vkd3d-1.9.tar.xz
+        sha256: 9d1ebc6f36cccf40cffda3176851f73a0501b90c4d04e782abe79ca703057a4b
     modules:
       - name: spirv-headers
         buildsystem: cmake-ninja

--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -115,6 +115,7 @@ separate-locales: false
 cleanup:
   - '*.a'
   - '*.la'
+  - /share/doc
   - /share/man
 
   - /bin/function_grep.pl


### PR DESCRIPTION
Changelog: https://source.winehq.org/git/vkd3d.git/blob_plain/vkd3d-1.9:/ANNOUNCE.

![Снимок экрана от 2023-10-04 22-03-24](https://github.com/flathub/org.winehq.Wine/assets/5614476/b5cb2fe7-5a28-4855-8663-800a1f9bed5d)
