### PR TITLE
Fix flathub linter errors and samba url

### DIFF
--- a/org.winehq.Wine.appdata.xml
+++ b/org.winehq.Wine.appdata.xml
@@ -5,7 +5,11 @@
   <metadata_license>FSFAP</metadata_license>
   <project_license>LGPL-2.1+</project_license>
   <name>Wine</name>
-  <summary>Run Windows applications on Linux, BSD, Solaris and Mac OS X</summary>
+  <summary>Windows compatibility layer</summary>
+  <developer_name>Wine Project</developer_name>
+  <developer id="winehq.org">
+    <name>Wine Project</name>
+  </developer>
 
   <description>
     <p>
@@ -28,15 +32,19 @@
 
   <screenshots>
     <screenshot type="default">
+      <caption>MS Outlook 2010 running via wine</caption>
       <image>https://dl.winehq.org/share/images/screenshots/outlook2010.jpg</image>
     </screenshot>
     <screenshot>
+      <caption>The Windows Steam client running on linux via wine</caption>
       <image>https://dl.winehq.org/share/images/screenshots/steam.jpg</image>
     </screenshot>
     <screenshot>
+      <caption>GOG Galaxy client running via wine</caption>
       <image>https://dl.winehq.org/share/images/screenshots/goggalaxy.jpg</image>
     </screenshot>
     <screenshot>
+      <caption>A horse in the game "Skyrim Special Edition" running via wine</caption>
       <image>https://dl.winehq.org/share/images/screenshots/skyrim_specialed.jpg</image>
     </screenshot>
   </screenshots>

--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -282,11 +282,11 @@ modules:
       - /sbin
     sources: &samba-sources
       - type: archive
-        url: https://download.samba.org/pub/samba/samba-4.19.2.tar.gz
+        url: https://download.samba.org/pub/samba/stable/samba-4.19.2.tar.gz
         sha256: 9e63f0505e1c631f1db0b7a9349a51e925c026ca03af3fd5d812228bb597d393
         x-checker-data:
           type: html
-          url: https://download.samba.org/pub/samba/
+          url: https://download.samba.org/pub/samba/stable/
           pattern: (samba-(\d+\.\d+\.\d+)\.tar\.gz)
     modules:
       - name: perl-Parse-Yapp


### PR DESCRIPTION
This MR doesn't update any packages, it just makes this repo more future proof.

Only the latest version of samba is stored in `pub/samba` by adding `/stable` old versions of this manifest will still build.

The linter issues were:
 * Missing developer_name field
 * Summary too long
 * Missing captions on screenshots
 * ~~wayland and x11 in finish-args~~