### PR TITLE
Remove --enable-win64 from Wine config opts for the WOW64 build

### DIFF
--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -130,7 +130,6 @@ modules:
     config-opts:
       - --libdir=/app/lib
       - --enable-archs=i386,x86_64
-      - --enable-win64
       - --disable-tests
       - --with-x
       - --with-wayland


### PR DESCRIPTION
Otherwise it will just create a pure 64 bit build instead of the WOW64 one.