### PR TITLE
Add --allow=multiarch back to the WOW64 manifest

### DIFF
--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -10,6 +10,7 @@ finish-args:
   - --device=all
   - --socket=pulseaudio
   - --share=network
+  - --allow=multiarch
   - --allow=devel
   - --system-talk-name=org.freedesktop.UDisks2
   - --system-talk-name=org.freedesktop.NetworkManager
@@ -225,8 +226,7 @@ modules:
         x-checker-data:
           type: html
           url: *wine-addons-url
-          version-pattern: &wine-gecko-version-pattern >-
-            GECKO_VERSION\s+"(\d[\d\.]+\d)"
+          version-pattern: GECKO_VERSION\s+"(\d[\d\.]+\d)"
           url-template: https://dl.winehq.org/wine/wine-gecko/$version/wine-gecko-$version-x86.tar.xz
       - type: archive
         url: https://dl.winehq.org/wine/wine-gecko/2.47.4/wine-gecko-2.47.4-x86_64.tar.xz
@@ -235,7 +235,7 @@ modules:
         x-checker-data:
           type: html
           url: *wine-addons-url
-          version-pattern: *wine-gecko-version-pattern
+          version-pattern: GECKO_VERSION\s+"(\d[\d\.]+\d)"
           url-template: https://dl.winehq.org/wine/wine-gecko/$version/wine-gecko-$version-x86_64.tar.xz
       - type: file
         path: org.winehq.Wine.gecko.metainfo.xml


### PR DESCRIPTION
By default, Flatpak blocks 32 bit syscalls, so if WOW64 still needs to pass 32 bit syscalls, it might be the reason why 32 Windows software didn't work previously.