### PR TITLE
Rename mono and gecko extensions in the WOW64 branch

### DIFF
--- a/org.winehq.Wine.gecko-wow64.metainfo.xml
+++ b/org.winehq.Wine.gecko-wow64.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="addon">
-  <id>org.winehq.Wine.gecko</id>  
+  <id>org.winehq.Wine.gecko-wow64</id>  
   <extends>org.winehq.Wine</extends>
   <name>Gecko</name>
   <summary>Web engine for Wine based on Mozilla Gecko</summary>

--- a/org.winehq.Wine.mono-wow64.metainfo.xml
+++ b/org.winehq.Wine.mono-wow64.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="addon">
-  <id>org.winehq.Wine.mono</id>  
+  <id>org.winehq.Wine.mono-wow64</id>  
   <extends>org.winehq.Wine</extends>
   <name>Mono</name>
   <summary>.NET Framework implementation for Wine based on Mono</summary>

--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -32,11 +32,11 @@ add-extensions:
     version: *runtime-version
     autodelete: false
 
-  org.winehq.Wine.gecko:
+  org.winehq.Wine.gecko-wow64:
     directory: share/wine/gecko
     bundle: true
 
-  org.winehq.Wine.mono:
+  org.winehq.Wine.mono-wow64:
     directory: share/wine/mono
     bundle: true
 
@@ -217,7 +217,7 @@ modules:
       - >-
         install -Dm644
         -t ${FLATPAK_DEST}/share/wine/gecko/share/metainfo/
-        ${FLATPAK_ID}.gecko.metainfo.xml
+        ${FLATPAK_ID}.gecko-wow64.metainfo.xml
     sources:
       - type: archive
         url: https://dl.winehq.org/wine/wine-gecko/2.47.4/wine-gecko-2.47.4-x86.tar.xz
@@ -238,7 +238,7 @@ modules:
           version-pattern: GECKO_VERSION\s+"(\d[\d\.]+\d)"
           url-template: https://dl.winehq.org/wine/wine-gecko/$version/wine-gecko-$version-x86_64.tar.xz
       - type: file
-        path: org.winehq.Wine.gecko.metainfo.xml
+        path: org.winehq.Wine.gecko-wow64.metainfo.xml
 
   - name: wine-mono
     buildsystem: simple
@@ -249,7 +249,7 @@ modules:
       - >-
         install -Dm644
         -t ${FLATPAK_DEST}/share/wine/mono/share/metainfo/
-        ${FLATPAK_ID}.mono.metainfo.xml
+        ${FLATPAK_ID}.mono-wow64.metainfo.xml
     sources:
       - type: archive
         url: https://dl.winehq.org/wine/wine-mono/9.4.0/wine-mono-9.4.0-x86.tar.xz
@@ -261,7 +261,7 @@ modules:
           version-pattern: MONO_VERSION\s+"(\d[\d\.]+\d)"
           url-template: https://dl.winehq.org/wine/wine-mono/$version/wine-mono-$version-x86.tar.xz
       - type: file
-        path: org.winehq.Wine.mono.metainfo.xml
+        path: org.winehq.Wine.mono-wow64.metainfo.xml
 
   # Flatpak bundle
 


### PR DESCRIPTION
The mono and gecko extensions in the wow64 branch must have a different id than the ones in the default stable branch, otherwise they won't be available to download for users of the stable branch.