### PR TITLE
WOW64 branch: Remove "default branch" from the manifest

### DIFF
--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -167,6 +167,7 @@ modules:
       - type: git
         url: https://github.com/Winetricks/winetricks.git
         tag: 20250102
+        commit: e20b2f6f80d175f96208f51800130db7459dd28c
         x-checker-data:
           type: git
           tag-pattern: ^(\d+)$

--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -1,5 +1,4 @@
 id: org.winehq.Wine
-default-branch: stable-24.08
 sdk: org.freedesktop.Sdk
 runtime: org.freedesktop.Platform
 runtime-version: &runtime-version '24.08'
@@ -167,8 +166,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/Winetricks/winetricks.git
-        tag: '20250102'
-        commit: e20b2f6f80d175f96208f51800130db7459dd28c
+        tag: 20250102
         x-checker-data:
           type: git
           tag-pattern: ^(\d+)$


### PR DESCRIPTION
The new Vorarbeiter build infra doesn't publish new builds properly most likely because of this line.