### PR TITLE
Stable branch: Add Samba + other tweaks

### DIFF
--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -277,6 +277,7 @@ modules:
       - --without-ldap
       - --without-acl-support
       - --without-systemd
+      - --without-ldb-lmdb
     cleanup:
       - /bin
     sources:

--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -1,6 +1,5 @@
 id: org.winehq.Wine
-default-branch: &app-version stable-24.08
-x-extension-versions: &extension-versions stable;stable-24.08
+default-branch: stable-24.08
 sdk: org.freedesktop.Sdk
 runtime: org.freedesktop.Platform
 runtime-version: &runtime-version '24.08'
@@ -100,6 +99,9 @@ sdk-extensions:
 
 build-options:
   append-path: /usr/lib/sdk/mingw-w64/bin
+  env:
+    PERL5LIB: /app/lib/perl5/
+    PERL_MM_OPT: INSTALL_BASE=/app
 
 x-compat-i386-opts: &compat_i386_opts
   prepend-pkg-config-path: /app/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig
@@ -161,12 +163,9 @@ modules:
     config-opts: &krb5-config-opts
       - --localstatedir=/var/lib
       - --sbindir=${FLATPAK_DEST}/bin
-      - --disable-static
       - --disable-rpath
     cleanup: &krb5-cleanup
       - /bin
-      - /share/et
-      - /share/examples
     sources: &krb5-sources
       - type: archive
         url: https://github.com/krb5/krb5/archive/refs/tags/krb5-1.21.3-final.tar.gz
@@ -193,12 +192,14 @@ modules:
   - name: krb5-config
     buildsystem: simple
     build-commands:
-      - install -Dm 644 krb5.conf -t /app/etc
+      - install -Dm644 krb5.conf -t /app/etc
     sources:
       - type: file
         path: krb5.conf
 
   - name: unixodbc
+    cleanup: &unixodbc-cleanup
+      - /bin
     sources: &unixodbc-sources
       - type: archive
         url: https://github.com/lurcher/unixODBC/releases/download/2.3.12/unixODBC-2.3.12.tar.gz
@@ -208,8 +209,6 @@ modules:
           project-id: 7344
           stable-only: true
           url-template: https://github.com/lurcher/unixODBC/releases/download/$version/unixODBC-$version.tar.gz
-    cleanup: &unixodbc-cleanup
-      - /bin
 
   - name: unixodbc-32bit
     build-options:
@@ -231,6 +230,64 @@ modules:
           project-id: 223257
           stable-only: true
           url-template: https://github.com/KhronosGroup/OpenCL-Headers/archive/refs/tags/v$version.tar.gz
+
+  # Samba + dependencies
+
+  - name: parse-yapp
+    buildsystem: simple
+    build-commands:
+      - perl Makefile.PL
+      - make install
+    cleanup:
+      - "*"
+    sources:
+      - type: archive
+        url: https://cpan.metacpan.org/authors/id/W/WB/WBRASWELL/Parse-Yapp-1.21.tar.gz
+        sha256: 3810e998308fba2e0f4f26043035032b027ce51ce5c8a52a8b8e340ca65f13e5
+        x-checker-data:
+          type: anitya
+          project-id: 3197
+          stable-only: true
+          url-template: https://cpan.metacpan.org/authors/id/W/WB/WBRASWELL/Parse-Yapp-$version.tar.gz
+
+  - name: rpcsvc-proto
+    cleanup:
+      - '*'
+    sources:
+      - type: archive
+        url: https://github.com/thkukuk/rpcsvc-proto/releases/download/v1.4.4/rpcsvc-proto-1.4.4.tar.xz
+        sha256: 81c3aa27edb5d8a18ef027081ebb984234d5b5860c65bd99d4ac8f03145a558b
+        x-checker-data:
+          type: anitya
+          project-id: 155452
+          stable-only: true
+          url-template: https://github.com/thkukuk/rpcsvc-proto/releases/download/v$version/rpcsvc-proto-$version.tar.xz
+
+  - name: samba
+    config-opts:
+      - --localstatedir=/var
+      - --sharedstatedir=/var/lib
+      - --sbindir=/app/bin
+      - --enable-fhs
+      - --disable-python
+      - --without-json
+      - --without-ad-dc
+      - --without-ads
+      - --without-pam
+      - --without-ldap
+      - --without-acl-support
+      - --without-systemd
+    cleanup:
+      - /bin
+    sources:
+      - type: archive
+        url: https://samba.org/samba/ftp/stable/samba-4.22.3.tar.gz
+        sha256: 8fd7092629a3596d935cd7567d934979f94272918ec3affd0cc807934ecf22ba
+        x-checker-data:
+          type: anitya
+          project-id: 4758
+          stable-only: true
+          url-template: https://samba.org/samba/ftp/stable/samba-$version.tar.gz
 
   # Native arch build
 
@@ -401,7 +458,7 @@ modules:
       - |
         icondir=${FLATPAK_DEST}/share/icons/hicolor
         install -Dm644 wine-logo.svg ${icondir}/scalable/apps/wine.svg
-        for s in 64 128 256; do
+        for s in 16 32 48 64 128 256; do
           mkdir -p ${icondir}/${s}x${s}/apps
           rsvg-convert -h ${s} -a -o ${icondir}/${s}x${s}/apps/wine.png ${icondir}/scalable/apps/wine.svg
         done


### PR DESCRIPTION
It appears quite noticeable amount of Windows software relies on ntlm_auth functionality which Samba provides. I've seen a lot of complaints about missing ntlm_auth support, particularly among Bottles users.