### PR TITLE
Stable branch: Also build Samba 32 bit

### DIFF
--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -291,15 +291,15 @@ modules:
           url-template: https://samba.org/samba/ftp/stable/samba-$version.tar.gz
 
   - name: samba-32bit
-      build-options:
-        arch:
-          x86_64: *compat_i386_opts
-        config-opts:
-          - --sbindir=bin32
-      config-opts: *samba-config-opts
-      cleanup:
-        - /bin32
-      sources: *samba-sources
+    build-options:
+      arch:
+        x86_64: *compat_i386_opts
+      config-opts:
+        - --sbindir=bin32
+    config-opts: *samba-config-opts
+    cleanup:
+      - /bin32
+    sources: *samba-sources
 
   # Native arch build
 

--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -264,7 +264,7 @@ modules:
           url-template: https://github.com/thkukuk/rpcsvc-proto/releases/download/v$version/rpcsvc-proto-$version.tar.xz
 
   - name: samba
-    config-opts:
+    config-opts: &samba-config-opts
       - --localstatedir=/var
       - --sharedstatedir=/var/lib
       - --sbindir=/app/bin
@@ -280,7 +280,7 @@ modules:
       - --without-ldb-lmdb
     cleanup:
       - /bin
-    sources:
+    sources: &samba-sources
       - type: archive
         url: https://samba.org/samba/ftp/stable/samba-4.22.3.tar.gz
         sha256: 8fd7092629a3596d935cd7567d934979f94272918ec3affd0cc807934ecf22ba

--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -239,7 +239,7 @@ modules:
       - perl Makefile.PL
       - make install
     cleanup:
-      - "*"
+      - '*'
     sources:
       - type: archive
         url: https://cpan.metacpan.org/authors/id/W/WB/WBRASWELL/Parse-Yapp-1.21.tar.gz
@@ -289,6 +289,17 @@ modules:
           project-id: 4758
           stable-only: true
           url-template: https://samba.org/samba/ftp/stable/samba-$version.tar.gz
+
+  - name: samba-32bit
+      build-options:
+        arch:
+          x86_64: *compat_i386_opts
+        config-opts:
+          - --sbindir=bin32
+      config-opts: *samba-config-opts
+      cleanup:
+        - /bin32
+      sources: *samba-sources
 
   # Native arch build
 
@@ -459,7 +470,7 @@ modules:
       - |
         icondir=${FLATPAK_DEST}/share/icons/hicolor
         install -Dm644 wine-logo.svg ${icondir}/scalable/apps/wine.svg
-        for s in 16 32 48 64 128 256; do
+        for s in 16 24 32 48 64 128 256; do
           mkdir -p ${icondir}/${s}x${s}/apps
           rsvg-convert -h ${s} -a -o ${icondir}/${s}x${s}/apps/wine.png ${icondir}/scalable/apps/wine.svg
         done


### PR DESCRIPTION
While looking at the last build log, I noticed Wine 32 bit configure script complained that Samba was not found. So it also needs Samba 32 bit.