### PR TITLE
Stable branch: Don't cleanup Wine tools + small Parse-Yapp correction

### DIFF
--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -122,16 +122,6 @@ cleanup:
   - /share/et
   - /share/examples
   - /share/man
-  - /bin/function_grep.pl
-  - /bin/widl
-  - /bin/winebuild
-  - /bin/winecpp
-  - /bin/winedump
-  - /bin/wineg++
-  - /bin/winegcc
-  - /bin/winemaker
-  - /bin/wmc
-  - /bin/wrc
   - /bin32
   - /include
   - /lib/pkgconfig
@@ -241,6 +231,7 @@ modules:
     buildsystem: simple
     build-commands:
       - perl Makefile.PL
+      - make
       - make install
     cleanup:
       - '*'


### PR DESCRIPTION
Wine tools barely take any disk space and they might be useful for someone.