### PR TITLE
WOW64 branch: Rebuild to make it publish

### DIFF
--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -82,6 +82,8 @@ modules:
       - --localstatedir=/var/lib
       - --sbindir=${FLATPAK_DEST}/bin
       - --disable-rpath
+    post-install:
+      - install -Dm644 ../krb5.conf -t /app/etc
     sources:
       - type: archive
         url: https://github.com/krb5/krb5/archive/refs/tags/krb5-1.21.3-final.tar.gz
@@ -91,18 +93,12 @@ modules:
           project-id: 13287
           stable-only: true
           url-template: https://github.com/krb5/krb5/archive/refs/tags/krb5-$version.tar.gz
+      - type: file
+        path: krb5.conf
       - type: shell
         dest: src
         commands:
-          - autoreconf -si
-
-  - name: krb5-config
-    buildsystem: simple
-    build-commands:
-      - install -Dm644 krb5.conf -t /app/etc
-    sources:
-      - type: file
-        path: krb5.conf
+          - autoreconf -vfi
 
   - name: unixodbc
     sources:


### PR DESCRIPTION
The last WOW64 build wasn't published for some reason. Also some small krb5 improvements.