### PR TITLE
Change update check interval to once a week + small tweaks

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,7 +1,7 @@
 name: Check for updates
 on:
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 1 * * 3'
   workflow_dispatch: {}
 jobs:
   flatpak-external-data-checker:

--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -171,7 +171,7 @@ modules:
       - type: shell
         dest: src
         commands:
-          - autoreconf -si
+          - autoreconf -vfi
 
   - name: krb5-32bit
     subdir: src
@@ -375,7 +375,7 @@ modules:
         subdir: CPP/7zip/Bundles/Alone2
         build-commands:
           - make -j $FLATPAK_BUILDER_N_JOBS -f makefile.gcc
-          - install -D ./_o/7zz -t /app/bin
+          - install -Dm755 ./_o/7zz -t /app/bin
           - ln -s /app/bin/7zz /app/bin/7za
           - ln -s /app/bin/7zz /app/bin/7z
         sources:


### PR DESCRIPTION
Since I intend to continue supporting the 24.08 branches for another year along with 25.08 branches, it would be redundant to check for updates every day, as that would put unnecessary strain on Flathub infra, particularly when 2 or more dependencies are updated within a single week.