### PR TITLE
Fix codecs_extra.i386

### DIFF
--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -4,7 +4,7 @@ sdk: org.freedesktop.Sdk
 runtime: org.freedesktop.Platform
 runtime-version: &runtime-version '25.08'
 x-gl-version: &gl-version '1.4'
-x-gl-versions: &gl-versions 25.08;1.4
+x-gl-versions: &gl-versions 25.08;25.08-extra;1.4
 x-gl-merge-dirs: &gl-merge-dirs vulkan/icd.d;glvnd/egl_vendor.d;egl/egl_external_platform.d;OpenCL/vendors;lib/dri;lib/d3d;lib/gbm;vulkan/explicit_layer.d;vulkan/implicit_layer.d
 finish-args:
   - --share=ipc

--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -73,10 +73,10 @@ add-extensions:
     autoprune-unless: have-intel-gpu
 
   org.freedesktop.Platform.codecs_extra.i386:
-    directory: lib32/codecs-extra
-    add-ld-path: .
-    version: *runtime-version
+    directory: lib/i386-linux-gnu/codecs-extra
+    version: '25.08-extra'
     autodelete: false
+    add-ld-path: lib
 
   org.winehq.Wine.gecko:
     directory: share/wine/gecko
@@ -123,7 +123,7 @@ cleanup:
   - /lib/wine/*.def
   - /lib32/wine/*.def
 cleanup-commands:
-  - mkdir -p ${FLATPAK_DEST}/lib32/codecs-extra
+  - mkdir -p ${FLATPAK_DEST}/lib/i386-linux-gnu/codecs-extra
 modules:
 
   # Wine dependencies


### PR DESCRIPTION
Main problem is wrong version (missing `-extra` suffix). Also put it under `/app/lib/i386-linux-gnu` for consistency with other extensions.