### PR TITLE
stable-25.08 branch: Fix Samba 4.23.0 libdir installation

### DIFF
--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -249,6 +249,7 @@ modules:
     build-options:
       config-opts:
         - --sbindir=bin
+        - --libdir=lib
         - --libexecdir=lib/libexec
     config-opts: &samba-config-opts
       - --localstatedir=/var

--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -248,9 +248,9 @@ modules:
   - name: samba
     build-options:
       config-opts:
-        - --sbindir=bin
-        - --libdir=lib
-        - --libexecdir=lib/libexec
+        - --sbindir=/app/bin
+        - --libdir=/app/lib
+        - --libexecdir=/app/lib/libexec
     config-opts: &samba-config-opts
       - --localstatedir=/var
       - --sharedstatedir=/var/lib
@@ -281,9 +281,9 @@ modules:
       arch:
         x86_64: *compat_i386_opts
       config-opts:
-        - --bindir=bin32
-        - --sbindir=bin32
-        - --libexecdir=lib32/libexec
+        - --bindir=/app/bin32
+        - --sbindir=/app/bin32
+        - --libexecdir=/app/lib32/libexec
     config-opts: *samba-config-opts
     sources: *samba-sources
 


### PR DESCRIPTION
I have no idea why, but for some reason Samba 4.23.0 has started installing its libraries into a separate lib64 directory, as I just noticed Wine's configure script has started complaining that Samba is not found. Explicitly setting libdir should hopefully fix that.