### PR TITLE
stable-25.08 branch: Update Samba to 4.23.1

### DIFF
--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -268,8 +268,8 @@ modules:
       - --without-ldb-lmdb
     sources: &samba-sources
       - type: archive
-        url: https://samba.org/samba/ftp/stable/samba-4.23.0.tar.gz
-        sha256: b0cb963a63eb1515227f3779a46d3a7f790c1bbfeeb4b31fd43e405eefe7a3af
+        url: https://samba.org/samba/ftp/stable/samba-4.23.1.tar.gz
+        sha256: a4fe464652c136600525dcd2665737c72248c6a49d9d5323661a683800c39f75
         x-checker-data:
           type: anitya
           project-id: 4758


### PR DESCRIPTION
It seems Samba 4.23.0 was released with broken winbind support. Since winbind is used by Wine, I'm updating it now (instead of waiting till Wednesday for it to update automatically), so apps utilizing Wine as baseapp won't be left with broken winbind if they'll update in the coming days.