### PR TITLE
stable-25.08 branch: A couple of tweaks

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         branch: [ branch/stable-25.08, branch/wow64-25.08, branch/stable-24.08, branch/wow64-24.08 ]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ matrix.branch }}
       - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest

--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -16,7 +16,6 @@ finish-args:
   - --allow=multiarch
   - --allow=devel
   - --system-talk-name=org.freedesktop.UDisks2
-  - --system-talk-name=org.freedesktop.NetworkManager
   - --filesystem=xdg-desktop
   - --filesystem=xdg-documents
   - --filesystem=xdg-pictures
@@ -208,7 +207,7 @@ modules:
           stable-only: true
           url-template: https://github.com/KhronosGroup/OpenCL-Headers/archive/refs/tags/v$version.tar.gz
 
-  # Samba + dependencies
+  # Samba + dependencies - For ntlm_auth and other functionalities in Wine
 
   - name: parse-yapp
     buildsystem: simple
@@ -254,6 +253,8 @@ modules:
       - --disable-rpath
       - --disable-rpath-install
       - --disable-python
+      - --disable-cups
+      - --disable-iprint
       - --without-json
       - --without-ad-dc
       - --without-ads


### PR DESCRIPTION
- Remove `--system-talk-name=org.freedesktop.NetworkManager`: Wine doesn't seem to be able to utilize networkmanager dbus service.

- Disable some printer related Samba functionality unneeded by Wine.