### PR TITLE
Test: Figure out Wine executable changes in recent devel versions

### DIFF
--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -301,8 +301,8 @@ modules:
       - INSTALL_PROGRAM_FLAGS=-s
     sources: &wine-sources
       - type: archive
-        url: https://dl.winehq.org/wine/source/10.0/wine-10.0.tar.xz
-        sha256: c5e0b3f5f7efafb30e9cd4d9c624b85c583171d33549d933cd3402f341ac3601
+        url: https://dl.winehq.org/wine/source/10.x/wine-10.19.tar.xz
+        sha256: 7cec58323c6f2aaee7aca93517379cbbfef96e2c2c580c68ff85dd000cbbdd46
         x-addons-url: &wine-addons-url >-
           https://gitlab.winehq.org/wine/wine/-/raw/stable/dlls/appwiz.cpl/addons.c
         x-checker-data:
@@ -324,11 +324,9 @@ modules:
         - --bindir=${FLATPAK_DEST}/bin32
         - --with-mingw="ccache i686-w64-mingw32-gcc"
       env:
-        LIBDIR: lib32
+        LIBDIR: lib
     config-opts: *wine-config-opts
     make-install-args: *wine-make-install-args
-    post-install:
-      - mv ${FLATPAK_DEST}/bin32/wine{,-preloader} ${FLATPAK_DEST}/bin/
     sources: *wine-sources
 
   # Tools
@@ -421,9 +419,9 @@ modules:
         ${FLATPAK_ID}.mono.metainfo.xml
     sources:
       - type: archive
-        url: https://dl.winehq.org/wine/wine-mono/9.4.0/wine-mono-9.4.0-x86.tar.xz
+        url: https://dl.winehq.org/wine/wine-mono/10.3.0/wine-mono-10.3.0-x86.tar.xz
         strip-components: 0
-        sha256: fd772219aacf46b825fa891a647af4a9ddf8439320101c231918b2037bf13858
+        sha256: 009651c4baa2c5010c70aa28728a85e24a04485ff0e22b8cd5eea4eb8959e72e
         x-checker-data:
           type: html
           url: *wine-addons-url

--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -320,7 +320,9 @@ modules:
     build-options:
       arch:
         x86_64: *compat_i386_opts
+        libdir: /app/lib
       config-opts:
+        - --libdir=/app/lib
         - --bindir=${FLATPAK_DEST}/bin32
         - --with-mingw="ccache i686-w64-mingw32-gcc"
       env:

--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -320,7 +320,7 @@ modules:
     build-options:
       arch:
         x86_64: *compat_i386_opts
-        libdir: /app/lib
+          libdir: /app/lib
       config-opts:
         - --libdir=/app/lib
         - --bindir=${FLATPAK_DEST}/bin32

--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -320,7 +320,13 @@ modules:
     build-options:
       arch:
         x86_64:
-          <<: *compat_i386_opts
+          prepend-pkg-config-path: /app/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig
+          ldflags: -L/app/lib32 -Wl,-rpath-link=/app/lib32 -Wl,-z,relro,-z,now -Wl,--as-needed
+          ldflags-override: true
+          append-path: /usr/lib/sdk/toolchain-i386/bin
+          env:
+            CC: ccache i686-unknown-linux-gnu-gcc
+            CXX: ccache i686-unknown-linux-gnu-g++
           libdir: /app/lib
       config-opts:
         - --bindir=${FLATPAK_DEST}/bin32

--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -319,10 +319,10 @@ modules:
       - x86_64
     build-options:
       arch:
-        x86_64: *compat_i386_opts
+        x86_64:
+          <<: *compat_i386_opts
           libdir: /app/lib
       config-opts:
-        - --libdir=/app/lib
         - --bindir=${FLATPAK_DEST}/bin32
         - --with-mingw="ccache i686-w64-mingw32-gcc"
       env:


### PR DESCRIPTION
One of the Wine 10.x versions has fundamentally changed how the main Wine executable works in the multilib build - there is now a single "wine" executable for both 64 and 32 bit archs instead of 2 executables for each arch.

Unfortunately I can't test this myself atm (maybe I'll be able towards the release of Wine 11.0), so if anyone is interested in testing this, you're welcome to report if everything works properly with these changes.