### PR TITLE
wine-32bit: Add codecs-extra to linker configuration

### DIFF
--- a/ld.so.conf
+++ b/ld.so.conf
@@ -1,2 +1,3 @@
 /app/lib32
+/app/lib/i386-linux-gnu/codecs-extra/lib
 /app/lib/i386-linux-gnu


### PR DESCRIPTION
The 32-bit runtime only links the free ffmpeg build. As a result, gst-libav is missing codecs which are available via the org.freedesktop.Platform.codecs_extra.i386 extension. Explicitly configure codecs-extra to include it with winegstreamer.