### PR TITLE
Test: Try building Wine without -z,now linker flag

### DIFF
--- a/org.winehq.Wine.yml
+++ b/org.winehq.Wine.yml
@@ -166,6 +166,9 @@ modules:
   # Wine WOW64 build
 
   - name: wine
+    build-options:
+      ldflags: -L/app/lib -Wl,-z,relro -Wl,--as-needed
+      ldflags-override: true
     config-opts:
       - --libdir=/app/lib
       - --enable-archs=i386,x86_64


### PR DESCRIPTION
I heard some linker flags like -z,now may cause deadlocks in some cases, particularly when multiple dependencies are loaded simultanously.
So I want to see if this will fix the winecfg audio tab freezing, as that seems to be exactly this case (it happens when Wine pulse and alsa drivers are loading simultanously).